### PR TITLE
Vagrant VM for MDID development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.pyo
 rooibos/settings_local.py
+rooibos/settings_local.*.py
 solr/logs/*.log
 solr/solr/data/
 apps/
@@ -22,6 +23,6 @@ bin-release-temp/
 .DS_Store
 SyncToy_*.dat
 rooibos/static/web.config
-venv/
+venv*/
 jmutools/workers/settings.py
 .vagrant/

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ SyncToy_*.dat
 rooibos/static/web.config
 venv/
 jmutools/workers/settings.py
+.vagrant/

--- a/.vagrant_provision/bootstrap.sh
+++ b/.vagrant_provision/bootstrap.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+##############################################################################
+# A Vagrant provisioning shell script to setup an MDID Development VM
+##############################################################################
+# Update our apt sources
+apt-get update
+
+# Make sure we are starting from an up-to-date system
+apt-get upgrade -y
+
+##############################################################################
+# Install MySQL
+##############################################################################
+# The mysql-server package interactively prompts for the root pasword to the
+# MySQL server.  These commands will cache the password settings, and they
+# will be used by the mysql-server package on installation.  Since this is
+# pretty insecure anyway, no attempt is made at using a secure password :)
+#
+# Sets the MySQL root password to 'mdid'
+echo mysql-server mysql-server/root_password password mdid | debconf-set-selections
+echo mysql-server mysql-server/root_password_again password mdid | debconf-set-selections
+
+# Now we can install the packages
+# mysql-server: The MySQL server
+# mysql-client: The MySQL client utilities
+# libmysqlclient-dev: MySQL developmental libraries, needed to build the python
+#   MySQL module
+apt-get install -y mysql-server mysql-client libmysqlclient-dev
+
+##############################################################################
+# Install other dependencies
+##############################################################################
+# Java is needed to run Solr
+apt-get install -y openjdk-7-jre-headless
+
+# RabbitMQ is needed to manage the worker jobs
+apt-get install -y rabbitmq-server
+
+# Memcached is used for ???
+apt-get install -y memcached
+
+##############################################################################
+# Setup init scripts for Solr
+##############################################################################
+# use sysv-rc-conf to manage runlevels
+apt-get install -y sysv-rc-conf
+
+# the solr init script will be copied to the /etc/init.d dir with vagrant file
+# provisioning
+# TODO: set runlevels for the solr init script and start the service
+
+##############################################################################
+# Python build dependencies
+##############################################################################
+# Need the python development libs
+apt-get install -y python-dev
+
+# PyODBC needs the unixodbc libs
+apt-get install -y unixodbc unixodbc-dev
+
+# python-ldap needs ldap and sasl libraries
+apt-get install -y libldap2-dev libsasl2-dev
+
+# Pillow needs image libraries
+apt-get install -y libtiff5-dev libjpeg8-dev zlib1g-dev
+
+##############################################################################
+# Configure Python and setup a Virtual Environment
+##############################################################################
+# Use PIP for python package management
+apt-get install -y python-pip
+
+# install virtualenv
+pip install virtualenv
+
+# move into our project dir
+cd /vagrant
+
+# create a virtual environment (if needed)
+[[ ! -d venv/ ]] && virtualenv venv
+
+# enter our virtual environment
+source venv/bin/activate
+
+# install our requirements
+pip install -r requirements.txt
+
+##############################################################################
+# Configure MDID
+##############################################################################
+# create the MDID database
+mysql -uroot -pmdid < .vagrant_provision/create_database.sql
+
+# create the local settings
+cd rooibos
+cp settings_local_template.py settings_local.py
+# TODO: what all can we programatically set in the settings file, and what do
+#       we need to do manually?
+
+# setup the database
+python manage.py syncdb --noinput
+python manage.py createcachetable cache

--- a/.vagrant_provision/bootstrap.sh
+++ b/.vagrant_provision/bootstrap.sh
@@ -69,6 +69,10 @@ sudo -u vagrant ln -s $VAGRANT_DIR $MDID_DIR
 
 # create directories for our mdid data
 sudo -u vagrant mkdir $MDID_DATA_DIR
+# explicitly create the log directory, because when the workers service fires
+# up later in the provisioning, if they're not there then they will get
+# created by root and permissions will be all jacked up
+sudo -u vagrant mkdir -p $MDID_DATA_DIR/scratch/logs
 
 # link in a little helper script for running the django dev server
 sudo -u vagrant ln -s $PROVISION_DIR/runserver $HOME_DIR/

--- a/.vagrant_provision/create_database.sql
+++ b/.vagrant_provision/create_database.sql
@@ -1,0 +1,7 @@
+CREATE DATABASE rooibos CHARACTER SET utf8;
+GRANT ALL PRIVILEGES ON rooibos.* TO rooibos@localhost IDENTIFIED BY 'rooibos';
+UPDATE mysql.user SET
+    Select_priv='Y', Insert_priv='Y', Update_priv='Y', Delete_priv='Y',
+    Create_priv='Y', Drop_priv='Y', Index_priv='Y', Alter_priv='y'
+    WHERE Host='localhost' AND User='rooibos';
+FLUSH PRIVILEGES;

--- a/.vagrant_provision/mdid3-solr.conf
+++ b/.vagrant_provision/mdid3-solr.conf
@@ -1,0 +1,14 @@
+# mdid3-solr - Solr full-text index for MDID3
+#
+# The Solr server in MDID3 provides full-text indexing for MDID metadata
+
+description "MDID3 Solr"
+author "Leighton Shank <shanklt@jmu.edu>"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+console log
+
+chdir /vagrant/solr
+exec /usr/bin/java -jar start.jar

--- a/.vagrant_provision/mdid3-solr.conf
+++ b/.vagrant_provision/mdid3-solr.conf
@@ -8,7 +8,10 @@ author "Leighton Shank <shanklt@jmu.edu>"
 start on runlevel [2345]
 stop on runlevel [!2345]
 
+respawn
+respawn limit 10 5
+
 console log
 
-chdir /vagrant/solr
+chdir /home/vagrant/mdid/solr
 exec /usr/bin/java -jar start.jar

--- a/.vagrant_provision/mdid3-workers.conf
+++ b/.vagrant_provision/mdid3-workers.conf
@@ -1,0 +1,20 @@
+# mdid3-workers - Run the MDID3 workers
+#
+# The MDID3 workers run jobs
+
+description "MDID3 Workers"
+author "Leighton Shank <shanklt@jmu.edu>"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+respawn limit 10 5
+
+# path to our python virtual env
+env PYTHON_VENV=/home/vagrant/mdid/venv.vagrant/bin
+
+console log
+
+chdir /home/vagrant/mdid/rooibos
+exec $PYTHON_VENV/python manage.py runworkers

--- a/.vagrant_provision/runserver
+++ b/.vagrant_provision/runserver
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+cd mdid
+source venv.vagrant/bin/activate
+cd rooibos
+python manage.py runserver 0.0.0.0:8000

--- a/.vagrant_provision/settings_local.vagrant.py
+++ b/.vagrant_provision/settings_local.vagrant.py
@@ -1,0 +1,158 @@
+DEBUG = True
+TEMPLATE_DEBUG = DEBUG
+LOGGING_OUTPUT_ENABLED = True
+
+# Needed to enable compression JS and CSS files
+COMPRESS = True
+MEDIA_URL = '/static/'
+MEDIA_ROOT = '/home/vagrant/mdid/rooibos/static/'
+
+
+ADMINS = (
+#    ('Your name', 'your@email.example'),
+)
+
+MANAGERS = ADMINS
+
+# Settings for MySQL
+DATABASE_ENGINE = 'mysql'           # 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
+DATABASE_OPTIONS = {
+    'use_unicode': True,
+    'charset': 'utf8',
+}
+
+# Settings for all database systems
+DATABASE_NAME = 'rooibos'             # Or path to database file if using sqlite3.
+DATABASE_USER = 'rooibos'             # Not used with sqlite3.
+DATABASE_PASSWORD = 'rooibos'         # Not used with sqlite3.
+DATABASE_HOST = ''             # Set to empty string for localhost. Not used with sqlite3.
+DATABASE_PORT = ''             # Set to empty string for default. Not used with sqlite3.
+
+DEFAULT_CHARSET = 'utf-8'
+DATABASE_CHARSET = 'utf8'
+
+CLOUDFILES_API_KEY = ''
+
+# Local time zone for this installation. Choices can be found here:
+# http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
+# although not all choices may be available on all operating systems.
+# If running in a Windows environment this must be set to the same as your
+# system time zone.
+TIME_ZONE = 'America/New_York'
+
+# Make this unique, and don't share it with anybody.
+SECRET_KEY = 'e#!poDuIJ}N,".K=H:T/4z5POb;Gl/N6$6a&,(DRAHUF5c",_p'
+
+# URL prefix for admin media -- CSS, JavaScript and images. Make sure to use a
+# trailing slash.
+# Examples: "http://foo.com/media/", "/media/".
+ADMIN_MEDIA_PREFIX = '/static/admin/'
+
+SOLR_URL = 'http://127.0.0.1:8983/solr/'
+
+SCRATCH_DIR = '/home/vagrant/mdid_data/scratch/'
+AUTO_STORAGE_DIR = '/home/vagrant/mdid_data/collections/'
+
+# Legacy setting for ImageViewer 2 support
+SECURE_LOGIN = False
+
+
+LOGIN_URL = '/login/'
+LOGIN_REDIRECT_URL = '/'
+LOGOUT_URL = '/'
+
+CACHE_BACKEND = 'memcached://127.0.0.1:11211/'
+
+INTERNAL_IPS = ('127.0.0.1','<<GATEWAY_IP>>',)
+
+HELP_URL = 'http://mdid.org/help/'
+
+DEFAULT_LANGUAGE = 'en-us'
+
+GOOGLE_ANALYTICS_MODEL = True
+
+FLICKR_KEY = ''
+FLICKR_SECRET = ''
+
+# Set to None if you don't subscribe to ARTstor
+ARTSTOR_GATEWAY = None
+#ARTSTOR_GATEWAY = 'http://sru.artstor.org/SRU/artstor.htm'
+
+#OPEN_OFFICE_PATH = 'C:/Program Files (x86)/OpenOffice.org 3/program/'
+#FFMPEG_EXECUTABLE = 'c:/mdid/dist/windows/ffmpeg/bin/ffmpeg.exe'
+
+GEARMAN_SERVERS = ['127.0.0.1']
+
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
+    'rooibos.auth.ldapauth.LdapAuthenticationBackend',
+#    'rooibos.auth.mailauth.ImapAuthenticationBackend',
+#    'rooibos.auth.mailauth.PopAuthenticationBackend',
+)
+
+MIDDLEWARE_CLASSES = (
+    'rooibos.auth.middleware.BasicAuthenticationMiddleware',
+)
+
+LDAP_AUTH = (
+    {
+         # LDAP Example
+        'uri': 'ldap://ldap.example.edu',
+        'base': 'ou=People,o=example',
+        'cn': 'cn',
+        'dn': 'dn',
+        'version': 2,
+        'scope': 1,
+        'options': {'OPT_X_TLS_TRY': 1},
+        'attributes': ('sn', 'mail', 'givenName', 'eduPersonPrimaryAffiliation'),
+        'firstname': 'givenname',
+        'lastname': 'sn',
+        'email': 'mail',
+        'bind_user': '',
+        'bind_password': '',
+   },
+)
+
+IMAP_AUTH = ()
+
+POP_AUTH = ()
+
+SESSION_COOKIE_AGE = 6 * 3600  # in seconds
+
+SSL_PORT = None  # ':443'
+
+# Theme colors for use in CSS
+PRIMARY_COLOR = "rgb(152, 189, 198)"
+SECONDARY_COLOR = "rgb(118, 147, 154)"
+
+EMAIL_HOST = '127.0.0.1'
+SERVER_EMAIL = 'mdid@example.edu'
+
+CUSTOM_TRACKER_HTML = ""
+
+UPLOAD_LIMIT = 500000 # upload limit in kB
+
+EXPOSE_TO_CONTEXT = (
+    'STATIC_DIR',
+    'PRIMARY_COLOR',
+    'SECONDARY_COLOR',
+    'CUSTOM_TRACKER_HTML',
+    'ADMINS',
+    'UPLOAD_LIMIT',
+)
+
+MEGAZINE_PUBLIC_KEY = ""
+
+FLOWPLAYER_KEY = ""
+
+# By default, video delivery links are created as symbolic links. Some streaming
+# servers (e.g. Wowza) don't deliver those, so hard links are required.
+HARD_VIDEO_DELIVERY_LINKS = False
+
+additional_settings = [
+#    'apps.jmutube.settings_local',
+#    'apps.snp.settings_local',
+#    'apps.furiousflower.settings_local',
+#    'apps.ovc.settings_local',
+#    'apps.thebreeze.settings_local',
+]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.provision :shell, path: '.vagrant_provision/bootstrap.sh'
-  config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network "forwarded_port", guest: 8000, host: 8888
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provision :shell, path: '.vagrant_provision/bootstrap.sh'
+  config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,13 +8,4 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.provision :shell, path: '.vagrant_provision/bootstrap.sh'
   config.vm.network "forwarded_port", guest: 8000, host: 8888
-
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
 end


### PR DESCRIPTION
Here's a Vagrant VM that can be used for MDID development, to avoid having to install all dependencies on your local machine.  It wraps up the setup of the VM and initial configuration of MDID nicely.

The VM is based off of the Ubuntu 14.04 LTS ("trusty").  I made this choice because it seemed to have the best version of Python within the distro, without having to install a secondary version.  "Trusty" uses Python 2.7.6, but seems to have the most active backports from the Python mainline for bug and security fixes.  Centos 6.5 is way back at Python 2.6.6, and Centos 7.0 is at 2.7.5, but didn't seem to have as active of backports (or at least as far as I could tell, I may be wrong about that).  Anywho, Ubuntu is just a nice and friendly distro and made it easy to work with in creating the VM :smile_cat: 