### PR TITLE
Match up media improvements

### DIFF
--- a/rooibos/migration/management/commands/mdid2migrate.py
+++ b/rooibos/migration/management/commands/mdid2migrate.py
@@ -590,6 +590,8 @@ class MigrateCollectionItems(MigrateModel):
 
 class MigrateMedia(MigrateModel):
 
+    remove_full_prefix = False
+
     def __init__(self, cursor):
         super(MigrateMedia, self).__init__(cursor=cursor, model=Media,
                                            query="SELECT ID,Resource,CollectionID FROM Images")
@@ -600,7 +602,10 @@ class MigrateMedia(MigrateModel):
         return content_hash(row.Resource)
 
     def update(self, instance, row):
-        instance.url = os.path.join('full', row.Resource.strip())
+        if self.remove_full_prefix:
+            instance.url = row.Resource.strip()
+        else:
+            instance.url = os.path.join('full', row.Resource.strip())
 
     def create_instance(self, row):
         if not self.records.has_key(str(row.ID)) or not self.storages.has_key(str(row.CollectionID)):
@@ -1023,6 +1028,11 @@ class Command(BaseCommand):
     help = 'Migrates database from MDID2'
     args = "config_file"
 
+    option_list = BaseCommand.option_list + (
+        make_option('--remove-full-prefix', dest='remove_full_prefix', action='store_true',
+                    help='Remove full/ prefix from media paths'),
+    )
+
     def readConfig(self, file):
         connection = servertype = None
         for e in minidom.parse(file).getElementsByTagName('database')[0].childNodes:
@@ -1068,6 +1078,8 @@ class Command(BaseCommand):
             print "Database version is not supported"
             print "Found %r, supported is %r" % (row.Version, supported)
             return
+
+        MigrateMedia.remove_full_prefix = options.get('remove_full_prefix')
 
         import rooibos.solr.models
         rooibos.solr.models.SolrIndexUpdates.objects.all().delete()

--- a/rooibos/storage/__init__.py
+++ b/rooibos/storage/__init__.py
@@ -188,8 +188,8 @@ def find_record_by_identifier(identifiers, collection, owner=None,
     return records
 
 
-def match_up_media(storage, collection):
-    _broken, files = analyze_media(storage)
+def match_up_media(storage, collection, allow_multiple_use=False):
+    _broken, files = analyze_media(storage, allow_multiple_use)
     # find records that have an ID matching one of the remaining files
     for file in files:
         # Match identifiers that are either full file name (with extension) or just base name match
@@ -205,7 +205,7 @@ def analyze_records(collection, storage):
     return collection.records.exclude(id__in=collection.records.filter(media__storage=storage).values('id'))
 
 
-def analyze_media(storage):
+def analyze_media(storage, allow_multiple_use=False):
     broken = []
     extra = []
     # Storage must be able to provide file list
@@ -219,7 +219,8 @@ def analyze_media(storage):
             url = os.path.normcase(os.path.normpath(media.url))
             if extra.has_key(url):
                 # File is in use
-                del extra[url]
+                if not allow_multiple_use:
+                    del extra[url]
             else:
                 # missing file
                 broken.append(media)

--- a/rooibos/storage/__init__.py
+++ b/rooibos/storage/__init__.py
@@ -228,9 +228,9 @@ def analyze_media(storage, allow_multiple_use=False, remove_used_from_extra=True
             else:
                 # missing file
                 broken.append(media)
-        extra = extra.keys()
         if remove_used_from_extra:
             for url in used:
                 if url in extra:
-                    extra.remove(url)
+                    del extra[url]
+        extra = extra.keys()
     return broken, extra

--- a/rooibos/storage/__init__.py
+++ b/rooibos/storage/__init__.py
@@ -228,5 +228,6 @@ def analyze_media(storage, allow_multiple_use=False):
                 broken.append(media)
         extra = extra.keys()
         for url in used:
-            extra.remove(url)
+            if url in extra:
+                extra.remove(url)
     return broken, extra

--- a/rooibos/storage/__init__.py
+++ b/rooibos/storage/__init__.py
@@ -207,7 +207,7 @@ def analyze_records(collection, storage):
 
 def analyze_media(storage, allow_multiple_use=False):
     broken = []
-    extra = []
+    used = []
     # Storage must be able to provide file list
     if hasattr(storage, 'get_files'):
         # Find extra files, i.e. files in the storage area that don't have a matching media record
@@ -221,8 +221,12 @@ def analyze_media(storage, allow_multiple_use=False):
                 # File is in use
                 if not allow_multiple_use:
                     del extra[url]
+                else:
+                    used.append(url)
             else:
                 # missing file
                 broken.append(media)
         extra = extra.keys()
+        for url in used:
+            extra.remove(url)
     return broken, extra

--- a/rooibos/storage/__init__.py
+++ b/rooibos/storage/__init__.py
@@ -189,7 +189,9 @@ def find_record_by_identifier(identifiers, collection, owner=None,
 
 
 def match_up_media(storage, collection, allow_multiple_use=False):
-    _broken, files = analyze_media(storage, allow_multiple_use)
+    # While matching up when multiple use is allowed, we want to get all
+    # the files that are already in use as well, so they can be matched up again
+    _broken, files = analyze_media(storage, allow_multiple_use, remove_used_from_extra=not allow_multiple_use)
     # find records that have an ID matching one of the remaining files
     for file in files:
         # Match identifiers that are either full file name (with extension) or just base name match
@@ -205,7 +207,7 @@ def analyze_records(collection, storage):
     return collection.records.exclude(id__in=collection.records.filter(media__storage=storage).values('id'))
 
 
-def analyze_media(storage, allow_multiple_use=False):
+def analyze_media(storage, allow_multiple_use=False, remove_used_from_extra=True):
     broken = []
     used = []
     # Storage must be able to provide file list
@@ -227,7 +229,8 @@ def analyze_media(storage, allow_multiple_use=False):
                 # missing file
                 broken.append(media)
         extra = extra.keys()
-        for url in used:
-            if url in extra:
-                extra.remove(url)
+        if remove_used_from_extra:
+            for url in used:
+                if url in extra:
+                    extra.remove(url)
     return broken, extra

--- a/rooibos/storage/__init__.py
+++ b/rooibos/storage/__init__.py
@@ -195,7 +195,7 @@ def match_up_media(storage, collection, allow_multiple_use=False):
         # Match identifiers that are either full file name (with extension) or just base name match
         filename = os.path.split(file)[1]
         id = os.path.splitext(filename)[0]
-        records = find_record_by_identifier((id, filename,), collection, ignore_suffix=True)
+        records = find_record_by_identifier((id, filename,), collection, ignore_suffix=True).filter(media=None)
         if len(records) == 1:
             yield records[0], file
 

--- a/rooibos/storage/__init__.py
+++ b/rooibos/storage/__init__.py
@@ -197,7 +197,7 @@ def match_up_media(storage, collection, allow_multiple_use=False):
         # Match identifiers that are either full file name (with extension) or just base name match
         filename = os.path.split(file)[1]
         id = os.path.splitext(filename)[0]
-        records = find_record_by_identifier((id, filename,), collection, ignore_suffix=True).filter(media=None)
+        records = find_record_by_identifier((id, filename,), collection, ignore_suffix=True).filter(media=None).distinct()
         if len(records) == 1:
             yield records[0], file
 

--- a/rooibos/storage/templates/storage_analyze.html
+++ b/rooibos/storage/templates/storage_analyze.html
@@ -44,7 +44,7 @@
 <div style="float: left; margin-right: 20px; margin-top: 20px;">
     <h3>{{ broken|length|intcomma }} missing file{{ broken|length|pluralize }}</h3>
     <div style="overflow: auto; max-height: 600px; width: 400px; white-space: nowrap; font-size: smaller;">
-    {% for b in broken %}{{ b.url }}<br />{% empty %}None{% endfor %}
+    {% for b in broken %}{{ b }}<br />{% empty %}None{% endfor %}
     </div>
 </div>
 

--- a/rooibos/storage/templates/storage_match_up_files.html
+++ b/rooibos/storage/templates/storage_match_up_files.html
@@ -44,6 +44,12 @@ $(document).ready(function() {
 		<td>{{ form.storage }}
 		</td>
 	</tr>
+	<tr>
+		<th>{{ form.allow_multiple_use.label }}
+		</th>
+		<td>{{ form.allow_multiple_use }}  <small>Allow files to be attached to multiple records</small>
+		</td>
+	</tr>
 </table>
 <input type="submit" value="Match Up Media"/>
 </form>

--- a/rooibos/storage/views.py
+++ b/rooibos/storage/views.py
@@ -462,7 +462,7 @@ def match_up_files(request):
     class MatchUpForm(forms.Form):
         collection = forms.ChoiceField(choices=((c.id, c.title) for c in sorted(available_collections, key=lambda c: c.title)))
         storage = forms.ChoiceField(choices=available_storage)
-        allow_multiple_use = forms.BooleanField()
+        allow_multiple_use = forms.BooleanField(required=False)
 
     if request.method == 'POST':
 

--- a/rooibos/storage/views.py
+++ b/rooibos/storage/views.py
@@ -462,6 +462,7 @@ def match_up_files(request):
     class MatchUpForm(forms.Form):
         collection = forms.ChoiceField(choices=((c.id, c.title) for c in sorted(available_collections, key=lambda c: c.title)))
         storage = forms.ChoiceField(choices=available_storage)
+        allow_multiple_use = forms.BooleanField()
 
     if request.method == 'POST':
 
@@ -473,7 +474,7 @@ def match_up_files(request):
 
             job = JobInfo.objects.create(owner=request.user,
                 func='storage_match_up_media', arg=simplejson.dumps(dict(
-                collection=collection.id, storage=storage.id)))
+                collection=collection.id, storage=storage.id, allow_multiple_use=form.cleaned_data['allow_multiple_use'])))
             job.run()
 
             request.user.message_set.create(message='Match up media job has been submitted.')

--- a/rooibos/storage/views.py
+++ b/rooibos/storage/views.py
@@ -489,13 +489,13 @@ def match_up_files(request):
 
 
 @login_required
-def analyze(request, id, name):
+def analyze(request, id, name, allow_multiple_use=True):
     storage = get_object_or_404(filter_by_access(request.user, Storage.objects.filter(id=id), manage=True))
-    broken, extra = analyze_media(storage)
+    broken, extra = analyze_media(storage, allow_multiple_use)
     return render_to_response('storage_analyze.html',
                           {'storage': storage,
-                           'broken': broken,
-                           'extra': extra,
+                           'broken': sorted(broken),
+                           'extra': sorted(extra),
                            },
                           context_instance=RequestContext(request))
 

--- a/rooibos/storage/views.py
+++ b/rooibos/storage/views.py
@@ -492,6 +492,7 @@ def match_up_files(request):
 def analyze(request, id, name, allow_multiple_use=True):
     storage = get_object_or_404(filter_by_access(request.user, Storage.objects.filter(id=id), manage=True))
     broken, extra = analyze_media(storage, allow_multiple_use)
+    broken = [m.url for m in broken]
     return render_to_response('storage_analyze.html',
                           {'storage': storage,
                            'broken': sorted(broken),

--- a/rooibos/storage/workers.py
+++ b/rooibos/storage/workers.py
@@ -21,11 +21,12 @@ def storage_match_up_media_job(job):
 
     storage = Storage.objects.get(id=arg['storage'])
     collection = Collection.objects.get(id=arg['collection'])
+    allow_multiple_use = arg.get('allow_multiple_use')
 
     jobinfo.update_status('Analyzing available files')
 
     count = -1
-    for count, (record, filename) in enumerate(match_up_media(storage, collection)):
+    for count, (record, filename) in enumerate(match_up_media(storage, collection, allow_multiple_use)):
         id = os.path.splitext(os.path.split(filename)[1])[0]
         mimetype = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
         media = Media.objects.create(record=record,


### PR DESCRIPTION
* Optionally allow individual media files to be attached to more than one record
* Optionally remove `full/` prefix from media paths when migrating from MDID2