### PR TITLE
New permission to restrict personal records in collections

### DIFF
--- a/resources/docs/Limiting_personal_records_in_collections.md
+++ b/resources/docs/Limiting_personal_records_in_collections.md
@@ -1,0 +1,12 @@
+Limiting personal records in collections
+===
+
+By default, users can add personal records to any collection for which
+they have read access.  This can be problematic if a collection is
+supposed to be authoritative.
+
+To disallow the addition of personal records to a collection, add the
+following restriction to the permissions on the collection for the
+relevant users or groups:
+
+    personal=no

--- a/rooibos/data/templates/data_record.html
+++ b/rooibos/data/templates/data_record.html
@@ -319,7 +319,7 @@ Display metadata as: {{ fieldsetform.fieldset }}
 
     <div id="collection-membership-rows">
     {% for form in c_formset.forms %}
-    <div class="{% cycle 'altrow' '' %}">
+    <div class="{% cycle 'altrow' '' %}" style="clear: left;">
         <div>{{ form.id }}{{ form.title }}</div>
         <div>{{ form.member }}</div>
         <div>{{ form.shared }}</div>


### PR DESCRIPTION
By default, users can add personal records to any collection for which they have read access.  

To disallow the addition of personal records to a collection, add the following restriction to the permissions on the collection for the relevant users or groups:

    personal=no