### PR TITLE
Optimize metadata import

### DIFF
--- a/rooibos/data/spreadsheetimport.py
+++ b/rooibos/data/spreadsheetimport.py
@@ -203,6 +203,7 @@ class SpreadsheetImport(object):
                 record__collection__in=self.collections,
                 owner=None,
                 field__in=self._identifier_ids,
+                index_value__in=(x[:32] for x in ids),
                 value__in=ids)
             if not fvs:
                 if add:

--- a/rooibos/data/spreadsheetimport.py
+++ b/rooibos/data/spreadsheetimport.py
@@ -1,4 +1,5 @@
 from django.db.models import Q, Count
+from django.db import reset_queries
 from models import Field, FieldValue, Record, CollectionItem, get_system_field
 from rooibos.solr.models import delay_record_indexing, resume_record_indexing
 import csv
@@ -264,6 +265,7 @@ class SpreadsheetImport(object):
 
                 # On every row, delay record indexing for a little longer
                 delay_record_indexing()
+                reset_queries()
 
                 row = self._split_values(row)
                 if not last_row:


### PR DESCRIPTION
A simple change to the identifier lookup can speed up the import significantly (observed 4-5x for very large collections).

Also, reset logged queries if running in debug mode to preserve memory.